### PR TITLE
fixing install_go.py

### DIFF
--- a/library/install_go.py
+++ b/library/install_go.py
@@ -25,7 +25,7 @@ def main():
         target_version = "go" + target_version
     else:
         target_version = (
-            request.urlopen("https://go.dev/VERSION?m=text").read().decode("utf-8")
+            request.urlopen("https://go.dev/VERSION?m=text").read().decode("utf-8").split("\n")[0]
         )
     if "go" not in target_version:
         module.fail_json(f"Failed to fetch latest go version: {target_version}")


### PR DESCRIPTION
This should fix Go installation issues. 
The issue simply was that https://go.dev/VERSION?m=text adds a time stamp at the end now after a '\n'.
Fixed by taking only the data before '\n'.